### PR TITLE
Made possible to get an address of connection

### DIFF
--- a/client_ws.hpp
+++ b/client_ws.hpp
@@ -22,6 +22,8 @@ namespace SimpleWeb {
             friend class SocketClient<socket_type>;
 
         public:
+            boost::asio::ip::address address() { return socket->next_layer().remote_endpoint().address(); }
+        
             std::unordered_map<std::string, std::string> header;
             
             Connection(socket_type* socket): socket(socket), closed(false) {}


### PR DESCRIPTION
I'm not sure that I did this correct because I'm not an expert in boost::asio. This functionality seems to be quite important, at least I need it in the project I'm working on, and right now there is no way to get an information about connection.
