### PR TITLE
Fix ws_examples compilation on osx. wss_examples is broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Boost 1.54.0 COMPONENTS system regex thread REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
 if(APPLE)
-  set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+  set(OPENSSL_INCLUDE_DIR "/usr/local/opt/openssl/include")
 endif()
 
 #TODO: add requirement for version 1.0.1g (can it be done in one line?)


### PR DESCRIPTION
For the `wss_examples` I get the following error:

```bash
Undefined symbols for architecture x86_64:
  "_ERR_remove_thread_state", referenced from:
      boost::asio::ssl::detail::openssl_init_base::do_init::~do_init() in wss_examples.cpp.o
  "_TLSv1_1_client_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
  "_TLSv1_1_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
  "_TLSv1_1_server_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
  "_TLSv1_2_client_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
  "_TLSv1_2_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
  "_TLSv1_2_server_method", referenced from:
      boost::asio::ssl::context::context(boost::asio::ssl::context_base::method) in wss_examples.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [wss_examples] Error 1
make[1]: *** [CMakeFiles/wss_examples.dir/all] Error 2
make: *** [all] Error 2
```

Any ideas for a fix? Trying to address #18