### PR TITLE
Reset connection on SocketClientBase destruction

### DIFF
--- a/client_ws.hpp
+++ b/client_ws.hpp
@@ -228,6 +228,8 @@ namespace SimpleWeb {
             else
                 host=host_port_path.substr(0, host_end);
         }
+
+        ~SocketClientBase() { connection.reset(); }
         
         virtual void connect()=0;
         


### PR DESCRIPTION
Belongs to issue #27 
Deleting a SocketClient object causes a segfault. Resetting the shared connection ptr on client destruction fixes this problem.