### PR TITLE
Changed visibility of SocketServer<WS[S]>::accept().

### DIFF
--- a/server_ws.hpp
+++ b/server_ws.hpp
@@ -632,7 +632,7 @@ namespace SimpleWeb {
         SocketServer(unsigned short port, size_t num_threads=1, size_t timeout_request=5, size_t timeout_idle=0) : 
                 SocketServerBase<WS>::SocketServerBase(port, num_threads, timeout_request, timeout_idle) {};
         
-    private:
+    protected:
         void accept() {
             //Create new socket for this connection (stored in Connection::socket)
             //Shared_ptr is used to pass temporary objects to the asynchronous functions

--- a/server_wss.hpp
+++ b/server_wss.hpp
@@ -23,7 +23,7 @@ namespace SimpleWeb {
                 context.load_verify_file(verify_file);
         }
 
-    private:
+    protected:
         boost::asio::ssl::context context;
         
         void accept() {


### PR DESCRIPTION
Making accept() protected allows for a hook in start() prior to blocking on io_service.run().  eg, by overriding accept() a subclass could execute a callback that reports the random port that was bound if port = 0 was specified in the Config.