### PR TITLE
fixed bug with closing connection on client, when messages larger than 65535 bytes

### DIFF
--- a/server_ws.hpp
+++ b/server_ws.hpp
@@ -249,7 +249,7 @@ namespace SimpleWeb {
                 }
                 
                 for(int c=num_bytes-1;c>=0;c--) {
-                    header_stream->put((length>>(8*c))%256);
+                  header_stream->put((static_cast<unsigned long long>(length) >> (8 * c)) % 256);
                 }
             }
             else


### PR DESCRIPTION
- this bug occurs on systems where size_t is 32-bits unsigned int due to the peculiarities of the shift operation