### PR TITLE
Fixes some compiler errors in MSVS 2012 and a crash if server gets deleted directly after calling io_service->stop()

### DIFF
--- a/crypto.hpp
+++ b/crypto.hpp
@@ -11,6 +11,18 @@
 #include <openssl/md5.h>
 
 namespace SimpleWeb {
+    #if _MSC_VER == 1700 //MSVS 2012 has no definition for round()
+        #define ROUND_NS SimpleWeb::math
+
+        namespace math {
+            double round(double x) { //custom definition of round() for positive numbers
+                return floor(x + 0.5);
+            }
+        }
+    #else
+        #define ROUND_NS
+    #endif
+
     //type must support size(), resize() and operator[]
     namespace Crypto {
         namespace Base64 {
@@ -26,7 +38,7 @@ namespace SimpleWeb {
                 BIO_get_mem_ptr(b64, &bptr);
 
                 //Write directly to base64-buffer to avoid copy
-                int base64_length=static_cast<int>(round(4*ceil((double)ascii.size()/3.0)));
+                int base64_length=static_cast<int>(ROUND_NS::round(4*ceil((double)ascii.size()/3.0)));
                 base64.resize(base64_length);
                 bptr->length=0;
                 bptr->max=base64_length+1;

--- a/crypto.hpp
+++ b/crypto.hpp
@@ -12,15 +12,9 @@
 
 namespace SimpleWeb {
     #if _MSC_VER == 1700 //MSVS 2012 has no definition for round()
-        #define ROUND_NS SimpleWeb::math
-
-        namespace math {
-            double round(double x) { //custom definition of round() for positive numbers
-                return floor(x + 0.5);
-            }
+        double round(double x) { //custom definition of round() for positive numbers
+            return floor(x + 0.5);
         }
-    #else
-        #define ROUND_NS
     #endif
 
     //type must support size(), resize() and operator[]
@@ -38,7 +32,7 @@ namespace SimpleWeb {
                 BIO_get_mem_ptr(b64, &bptr);
 
                 //Write directly to base64-buffer to avoid copy
-                int base64_length=static_cast<int>(ROUND_NS::round(4*ceil((double)ascii.size()/3.0)));
+                int base64_length=static_cast<int>(round(4*ceil((double)ascii.size()/3.0)));
                 base64.resize(base64_length);
                 bptr->length=0;
                 bptr->max=base64_length+1;

--- a/server_ws.hpp
+++ b/server_ws.hpp
@@ -669,8 +669,10 @@ namespace SimpleWeb {
             std::shared_ptr<Connection> connection(new Connection(new WS(*io_service)));
             
             acceptor->async_accept(*connection->socket, [this, connection](const boost::system::error_code& ec) {
-                //Immediately start accepting a new connection
-                accept();
+                //Immediately start accepting a new connection (if io_service hasn't been stopped)
+                if (ec != boost::asio::error::operation_aborted)
+                    accept();
+
                 if(!ec) {
                     boost::asio::ip::tcp::no_delay option(true);
                     connection->socket->set_option(option);

--- a/server_ws.hpp
+++ b/server_ws.hpp
@@ -1,5 +1,5 @@
 #ifndef SERVER_WS_HPP
-#define	SERVER_WS_HPP
+#define SERVER_WS_HPP
 
 #include "crypto.hpp"
 
@@ -146,18 +146,32 @@ namespace SimpleWeb {
             friend class SocketServerBase<socket_type>;
         private:
             std::unordered_set<std::shared_ptr<Connection> > connections;
-            std::mutex connections_mutex;
+            std::unique_ptr<std::mutex> connections_mutex;
 
         public:            
+            Endpoint() : connections_mutex(new std::mutex) {}
+            Endpoint(Endpoint&& other) : connections_mutex(std::move(other.connections_mutex)), connections(std::move(other.connections)),
+                onopen(std::move(other.onopen)), onmessage(std::move(other.onmessage)), onerror(std::move(other.onerror)), 
+                onclose(std::move(other.onclose)) {}
+
+            Endpoint& operator=(Endpoint&& other) {
+                connections_mutex = std::move(other.connections_mutex);
+                connections = std::move(other.connections);
+                onopen = std::move(other.onopen);
+                onmessage = std::move(other.onmessage);
+                onerror = std::move(other.onerror);
+                onclose = std::move(other.onclose);
+            }
+
             std::function<void(std::shared_ptr<Connection>)> onopen;
             std::function<void(std::shared_ptr<Connection>, std::shared_ptr<Message>)> onmessage;
             std::function<void(std::shared_ptr<Connection>, const boost::system::error_code&)> onerror;
             std::function<void(std::shared_ptr<Connection>, int, const std::string&)> onclose;
             
             std::unordered_set<std::shared_ptr<Connection> > get_connections() {
-                connections_mutex.lock();
+                connections_mutex->lock();
                 auto copy=connections;
-                connections_mutex.unlock();
+                connections_mutex->unlock();
                 return copy;
             }
         };
@@ -309,7 +323,7 @@ namespace SimpleWeb {
         /// You might also want to set config.num_threads to 0.
         std::shared_ptr<boost::asio::io_service> io_service;
     protected:
-        const std::string ws_magic_string="258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+        const std::string ws_magic_string;
         
         std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor;
         
@@ -319,7 +333,7 @@ namespace SimpleWeb {
         size_t timeout_idle;
         
         SocketServerBase(unsigned short port, size_t num_threads, size_t timeout_request, size_t timeout_idle) : 
-                config(port, num_threads), timeout_request(timeout_request), timeout_idle(timeout_idle) {}
+                config(port, num_threads), timeout_request(timeout_request), timeout_idle(timeout_idle), ws_magic_string("258EAFA5-E914-47DA-95CA-C5AB0DC85B11") {}
         
         virtual void accept()=0;
         
@@ -578,9 +592,9 @@ namespace SimpleWeb {
         void connection_open(const std::shared_ptr<Connection> &connection, Endpoint& endpoint) {
             timer_idle_init(connection);
             
-            endpoint.connections_mutex.lock();
+            endpoint.connections_mutex->lock();
             endpoint.connections.insert(connection);
-            endpoint.connections_mutex.unlock();
+            endpoint.connections_mutex->unlock();
             
             if(endpoint.onopen)
                 endpoint.onopen(connection);
@@ -589,9 +603,9 @@ namespace SimpleWeb {
         void connection_close(const std::shared_ptr<Connection> &connection, Endpoint& endpoint, int status, const std::string& reason) const {
             timer_idle_cancel(connection);
             
-            endpoint.connections_mutex.lock();
+            endpoint.connections_mutex->lock();
             endpoint.connections.erase(connection);
-            endpoint.connections_mutex.unlock();    
+            endpoint.connections_mutex->unlock();    
             
             if(endpoint.onclose)
                 endpoint.onclose(connection, status, reason);
@@ -600,9 +614,9 @@ namespace SimpleWeb {
         void connection_error(const std::shared_ptr<Connection> &connection, Endpoint& endpoint, const boost::system::error_code& ec) const {
             timer_idle_cancel(connection);
             
-            endpoint.connections_mutex.lock();
+            endpoint.connections_mutex->lock();
             endpoint.connections.erase(connection);
-            endpoint.connections_mutex.unlock();
+            endpoint.connections_mutex->unlock();
             
             if(endpoint.onerror) {
                 boost::system::error_code ec_tmp=ec;
@@ -667,4 +681,4 @@ namespace SimpleWeb {
         }
     };
 }
-#endif	/* SERVER_WS_HPP */
+#endif  /* SERVER_WS_HPP */

--- a/server_wss.hpp
+++ b/server_wss.hpp
@@ -32,8 +32,9 @@ namespace SimpleWeb {
             std::shared_ptr<Connection> connection(new Connection(new WSS(*io_service, context)));
             
             acceptor->async_accept(connection->socket->lowest_layer(), [this, connection](const boost::system::error_code& ec) {
-                //Immediately start accepting a new connection
-                accept();
+                //Immediately start accepting a new connection (if io_service hasn't been stopped)
+                if (ec != boost::asio::error::operation_aborted)
+                    accept();
 
                 if(!ec) {
                     boost::asio::ip::tcp::no_delay option(true);


### PR DESCRIPTION
I know, you are not so much into supporting non C++11-standard compilers, so I can understand if you don't want to pull in the first commit 560cb90 (which looks a bit ugly).

The commit 6f6c1c9 should be important on any compiler (I am wondering, why this is compiling with other versions as `std::mutex` isn't copy- or movable and therefore Endpoint can't be used in an `std::map<>` like this).

cfa4f1f is a minor fix, for a problem, which is caused, by using a global `io_service`, which lives longer than the WebsocketServer instance. After calling `io_service::stop()` the acceptor gets notified of the stop, which ends in an access violation because he tries to call `accept()` on a deleted object.
