### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://github.com/eidheim/Simple-Web-Server for an easy way to make REST re
 * An easy to use WebSocket and WebSocket Secure client library
 * C++ bindings to the following OpenSSL methods: Base64, MD5, SHA1, SHA256 and SHA512 (found in crypto.hpp)
 
-###Usage
+### Usage
 
 See ws_examples.cpp or wss_examples.cpp for example usage. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
