### PR TITLE
rm const specifier

### DIFF
--- a/crypto.hpp
+++ b/crypto.hpp
@@ -59,7 +59,7 @@ namespace SimpleWeb {
         return base64;
       }
 
-      static std::string decode(const std::string &base64) noexcept {
+      static std::string decode(std::string &base64) noexcept {
         std::string ascii;
 
         // Resize ascii, however, the size is a up to two bytes too large.


### PR DESCRIPTION
I was having a problem on travis due to the const specifier in line 62 and 71 of the crypto.hpp file. 
By removing it it worked again. 

`In file included from /home/travis/build/vigilatore/traffic_monitor/external/Simple-WebSocket-Server/server_ws.hpp:4:0,
                 from /home/travis/build/vigilatore/traffic_monitor/src/main.cc:10:
/home/travis/build/vigilatore/traffic_monitor/external/Simple-WebSocket-Server/crypto.hpp: In static member function ‘static std::string SimpleWeb::Crypto::Base64::decode(const string&)’:
/home/travis/build/vigilatore/traffic_monitor/external/Simple-WebSocket-Server/crypto.hpp:71:74: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
         bio = BIO_new_mem_buf(&base64[0], static_cast<int>(base64.size()));
                                                                          ^
In file included from /usr/include/openssl/evp.h:75:0,
                 from /home/travis/build/vigilatore/traffic_monitor/external/Simple-WebSocket-Server/crypto.hpp:12,
                 from /home/travis/build/vigilatore/traffic_monitor/external/Simple-WebSocket-Server/server_ws.hpp:4,
                 from /home/travis/build/vigilatore/traffic_monitor/src/main.cc:10:
/usr/include/openssl/bio.h:668:6: error:   initializing argument 1 of ‘BIO* BIO_new_mem_buf(void*, int)’ [-fpermissive]
 BIO *BIO_new_mem_buf(void *buf, int len);
      ^`