### PR TITLE
Fix Pong payload

### DIFF
--- a/client_ws.hpp
+++ b/client_ws.hpp
@@ -587,8 +587,8 @@ namespace SimpleWeb {
 
             // Send pong
             auto pong_stream = std::make_shared<SendStream>();
-            *pong_stream << message->string();
-            connection->send(pong_stream, nullptr, fin_rsv_opcode + 1);
+            *pong_stream << connection->message->string();
+            connection->send(pong_stream, nullptr, connection->message->fin_rsv_opcode + 1);
 
             if(this->on_ping)
               this->on_ping(connection);

--- a/client_ws.hpp
+++ b/client_ws.hpp
@@ -586,8 +586,9 @@ namespace SimpleWeb {
             connection->set_timeout();
 
             // Send pong
-            auto empty_send_stream = std::make_shared<SendStream>();
-            connection->send(empty_send_stream, nullptr, connection->message->fin_rsv_opcode + 1);
+            auto pong_stream = std::make_shared<SendStream>();
+            *pong_stream << message->string();
+            connection->send(pong_stream, nullptr, fin_rsv_opcode + 1);
 
             if(this->on_ping)
               this->on_ping(connection);

--- a/server_ws.hpp
+++ b/server_ws.hpp
@@ -688,8 +688,9 @@ namespace SimpleWeb {
             connection->set_timeout();
 
             // Send pong
-            auto empty_send_stream = std::make_shared<SendStream>();
-            connection->send(empty_send_stream, nullptr, fin_rsv_opcode + 1);
+            auto pong_stream = std::make_shared<SendStream>();
+            *pong_stream << message->string();
+            connection->send(pong_stream, nullptr, fin_rsv_opcode + 1);
 
             if(endpoint.on_ping)
               endpoint.on_ping(connection);


### PR DESCRIPTION
According to the [Websocket RFC](https://tools.ietf.org/html/rfc6455#section-5.5.3), a Pong frame sent in response to a Ping frame must have identical "Application data" as found in the message body of the Ping frame being replied to.

The current implementation always sends an empty Pong message. Problems arise when communicating with other implementations conforming to the RFC, which would discard an empty Pong message, in case the original Ping message wasn't empty.

This pull request contains a fix to this issue.